### PR TITLE
Edit documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ sys.path.insert(0, os.path.abspath('../'))
 
 # -- Project information -----------------------------------------------------
 
-project = 'Classy Config'
+project = 'ClassyConfig'
 copyright = '2022, GDWR'
 author = 'GDWR'
 

--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -4,7 +4,8 @@ Getting Started
 Installation
 *************
 
-ClassyConfig is available on `pipy <https://pypi.org/project/classy-config/>`_, this will allow you to use ``pip`` to install ClassyConfig.
+ClassyConfig is available on `pypi <https://pypi.org/project/classy-config/>`_,
+making it easy to install via ``pip``:
 
 .. code-block::
 

--- a/docs/source/guides/custom-loaders.rst
+++ b/docs/source/guides/custom-loaders.rst
@@ -29,5 +29,5 @@ Here is an example of creating a simple config loader for ``.txt`` files.
     register_loader(".txt", txt_loader)
     register_config("config.txt")
 
-    print(f"data: {ConfigValue("data", int)}")
-    print(f"name: {ConfigValue("name", str)}")
+    print(f"data: {ConfigValue('data', int)}")
+    print(f"name: {ConfigValue('name', str)}")

--- a/docs/source/guides/custom-loaders.rst
+++ b/docs/source/guides/custom-loaders.rst
@@ -29,5 +29,5 @@ Here is an example of creating a simple config loader for ``.txt`` files.
     register_loader(".txt", txt_loader)
     register_config("config.txt")
 
-    print(f"data: {ConfigValue('data', int)}")
-    print(f"name: {ConfigValue('name', str)}")
+    print(f"data: {ConfigValue("data", int)}")
+    print(f"name: {ConfigValue("name", str)}")

--- a/docs/source/guides/load-your-config.rst
+++ b/docs/source/guides/load-your-config.rst
@@ -1,7 +1,7 @@
-Load your config
+Load Your Config
 ================
 
-ClassyConfig makes loading you config simple.
+ClassyConfig makes loading your config simple:
 
 .. code-block:: python
 
@@ -9,7 +9,8 @@ ClassyConfig makes loading you config simple.
 
     register_config(filepath="config.toml")
 
-Now you have registered your config, any usage of ``ConfigValue`` will be resolved from the config.
+Now that you have registered your config, any usage of ``ConfigValue``
+will be resolved from the registered config file:
 
 .. code-block:: python
 

--- a/docs/source/guides/using-multiple-configs.rst
+++ b/docs/source/guides/using-multiple-configs.rst
@@ -3,13 +3,13 @@ Using Multiple Configs
 
 `View on GitHub <https://github.com/GDWR/classy-config/tree/main/examples/multiple_configs>`_
 
-There maybe a time were having multiple config files would allow for cleaner deployment,
-readability and/or maintainability.
+There are times when having multiple config files would allow for cleaner deployment,
+readability, and maintainability of your code base.
 
-To accommodate this, ``ClassyConfig`` allows you to prefix your config files to allow them to be
-used alongside each other.
+To accommodate this, ``ClassyConfig`` allows you to load multiple config files
+with designated prefixes, so you can use all the config values alongside each other.
 
-So for this example, we have the following two configuration files.
+For example, we have the following two separate configuration files:
 
 ``config.toml``
 
@@ -26,14 +26,19 @@ So for this example, we have the following two configuration files.
     port=5432
 
 
-This is how they could be loaded, to run alongside each other.
+First, load your two configuration files. We'll use the prefix of ``"db"`` for the second one:
 
 .. code-block:: python
 
     from classy_config import register_config, ConfigValue
 
-    register_config(filepath="config.toml")  # This will allow gathering of all values, as usual
-    register_config(filepath="database.toml", prefix="database")  # This will allow gathering of all values, with the prefix 'database'
+    register_config(filepath="config.toml")
+    register_config(filepath="database.toml", prefix="db")  # Note the prefix
+
+
+Now use your config values from both files with ease:
+
+.. code-block:: python
 
     app_name = ConfigValue("app_name", str)
     print(f"Starting application: {app_name}")

--- a/docs/source/guides/using-multiple-configs.rst
+++ b/docs/source/guides/using-multiple-configs.rst
@@ -22,7 +22,7 @@ So for this example, we have the following two configuration files.
 
 .. code-block:: toml
 
-    host='127.0.0.1'
+    host="127.0.0.1"
     port=5432
 
 
@@ -35,11 +35,11 @@ This is how they could be loaded, to run alongside each other.
     register_config(filepath="config.toml")  # This will allow gathering of all values, as usual
     register_config(filepath="database.toml", prefix="database")  # This will allow gathering of all values, with the prefix 'database'
 
-    app_name = ConfigValue('app_name', str)
+    app_name = ConfigValue("app_name", str)
     print(f"Starting application: {app_name}")
 
-    database_host = ConfigValue('database.host', str)
-    database_port = ConfigValue('database.port', int)
+    database_host = ConfigValue("db.host", str)
+    database_port = ConfigValue("db.port", int)
     print(f"Connecting to database: {database_host}:{database_port}")
 
 

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -12,5 +12,3 @@ Subpackages
 
 .. toctree::
    :maxdepth: 4
-
-   classy_config.loader


### PR DESCRIPTION
This PR is a proofreading and light editing of the documentation for ClassyConfig.

Pages reviewed:

- [x] Getting Started
- [x] Load Your Config
- [x] Using Multiple Configs
- [ ] Conflicting Configs
- [ ] Custom Loaders
- [ ] Reference

Notes:
- Double quotes were more prevalent in the examples and so single quotes were converted to match
- Some examples are documented on the repo as well and should also be updated once satisfied with the changes (e.g.: [using multiple configs](https://github.com/GDWR/classy-config/tree/main/examples/multiple_configs))

Suggestions:
- It would be nice to capitalize the word "documentation" in the page title and banner
- Perhaps a link to the source code repository in the footer