### PR TITLE
ignore example files from linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,8 @@ exclude=
     .md,.svg,.png
     tests,
     venv,.venv,
-    __init__.py
+    __init__.py,
+    examples/
 
 ignore=
 


### PR DESCRIPTION
This is to prevent the large number of lint errors originating from this file. This will help tremendously with running linting locally when contributing. These example files are not meant to serve as working code for the application, so it makes sense to completely ignore them for linting. There are specific style choices in the example files that may be for the benefit of the user/reader and would not be useful for normal code styling on classy config.